### PR TITLE
client pop-up error management

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,32 +2,26 @@
 
 <app-popup-error></app-popup-error>
 
-<ng-container *ngIf="isAlive">
-    <ng-container *ngIf="isReadyForWork">
-        <app-new
-            *ngIf="!isAngularProject"
-            (sendCommand)="sendCommand($event)"
-            (changeAngularProjectStatus)="checkAngularProject($event)"
-            >
-        </app-new>
-        
-        <ng-container *ngIf="isAngularProject">
-            <app-serve (sendCommand)="sendCommand($event)"></app-serve>
-            <app-generate (sendCommand)="sendCommand($event)"></app-generate>
-            <button
-                (click)="leaveProject()">
-                Leave Project
-            </button>
-        </ng-container>
-    </ng-container>
-
-    <ng-container
-        *ngIf="!isReadyForWork"
-        class="blocker">
-        Please wait while the server is loading
+<ng-container *ngIf="isReadyForWork">
+    <app-new
+        *ngIf="!isAngularProject"
+        (sendCommand)="sendCommand($event)"
+        (changeAngularProjectStatus)="checkAngularProject($event)"
+        >
+    </app-new>
+    
+    <ng-container *ngIf="isAngularProject">
+        <app-serve (sendCommand)="sendCommand($event)"></app-serve>
+        <app-generate (sendCommand)="sendCommand($event)"></app-generate>
+        <button
+            (click)="leaveProject()">
+            Leave Project
+        </button>
     </ng-container>
 </ng-container>
 
-<ng-container *ngIf="!isAlive">
-    The server is offline, please run the server and restart the client
+<ng-container
+    *ngIf="!isReadyForWork"
+    class="blocker">
+    Please wait while the server is loading
 </ng-container>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,7 @@
 <h1>Angular CLI to UI</h1>
 
+<app-popup-error></app-popup-error>
+
 <ng-container *ngIf="isAlive">
     <ng-container *ngIf="isReadyForWork">
         <app-new
@@ -13,11 +15,9 @@
             <app-serve (sendCommand)="sendCommand($event)"></app-serve>
             <app-generate (sendCommand)="sendCommand($event)"></app-generate>
             <button
-                (click)="leaveProject()"
-                [disabled]="!isProjectLeavable">
+                (click)="leaveProject()">
                 Leave Project
             </button>
-            <div *ngIf="!isProjectLeavable">Can not leave this project</div>
         </ng-container>
     </ng-container>
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -82,7 +82,6 @@ export class AppComponent implements OnInit {
   }
 
   keepAlive(): void {
-    console.log('keep alive sending');
     this.subscription['TimedkeepAlive'] = timer(0, this.KEEP_ALIVE_INTERVAL)
       .pipe(
         exhaustMap(

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -118,5 +118,4 @@ export class AppComponent implements OnInit {
   addError(error: PopUpError): void {
     this.errorService.addError(error);
   }
-
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,6 +5,8 @@ import { interval } from 'rxjs';
 import { CommandService } from './services/command/command.service';
 import { CommandRequest } from './models/angular-command-request';
 import { AngularCliProcessStatus } from './models/angular-cli-process-status.enum';
+import { ErrorService } from './services/error/error.service';
+import { PopUpError } from './models/pop-up-error.interface';
 
 @Component({
   selector: 'app-root',
@@ -20,9 +22,10 @@ export class AppComponent implements OnInit {
   timedStatusCheck = interval(1000);
   subscription = {};
   isAlive = true;
-  isProjectLeavable = true;
 
-  constructor(private commandService: CommandService) {}
+  constructor(
+    private commandService: CommandService,
+    private errorService: ErrorService) {}
 
   ngOnInit() {
     this.keepAlive();
@@ -94,8 +97,12 @@ export class AppComponent implements OnInit {
     this.commandService.leaveProject()
       .subscribe(
         () => this.checkAngularProject(),
-        () => this.isProjectLeavable = false
-      );
+        () => {
+          this.errorService.addError({
+            errorText: 'Unable to leave this project',
+            errorDescription: 'To run ngWiz on another project or to create a new one, please run it in the apropriate project direcroty'
+          });
+        });
   }
 
   sendCommand(userCommand: string): void {
@@ -106,6 +113,10 @@ export class AppComponent implements OnInit {
       this.subscription[commandId] = this.timedStatusCheck
         .subscribe(() => this.startCheckingCommand(commandId));
     });
+  }
+
+  addError(error: PopUpError): void {
+    this.errorService.addError(error);
   }
 
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -25,7 +25,8 @@ export class AppComponent implements OnInit {
 
   constructor(
     private commandService: CommandService,
-    private errorService: ErrorService) {}
+    private errorService: ErrorService
+  ) {}
 
   ngOnInit() {
     this.keepAlive();
@@ -113,9 +114,5 @@ export class AppComponent implements OnInit {
       this.subscription[commandId] = this.timedStatusCheck
         .subscribe(() => this.startCheckingCommand(commandId));
     });
-  }
-
-  addError(error: PopUpError): void {
-    this.errorService.addError(error);
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -8,6 +8,7 @@ import { NewComponent } from './components/new/new.component';
 import { ServeComponent } from './components/serve/serve.component';
 import { GenerateComponent } from './components/generate/generate.component';
 import { CommandService } from './services/command/command.service';
+import { PopupErrorComponent } from './components/popup-error/popup-error.component';
 
 
 @NgModule({
@@ -15,7 +16,8 @@ import { CommandService } from './services/command/command.service';
     AppComponent,
     ServeComponent,
     NewComponent,
-    GenerateComponent
+    GenerateComponent,
+    PopupErrorComponent
   ],
   imports: [
     FormsModule,

--- a/src/app/components/popup-error/popup-error.component.css
+++ b/src/app/components/popup-error/popup-error.component.css
@@ -1,0 +1,3 @@
+.error {
+  color: red;
+}

--- a/src/app/components/popup-error/popup-error.component.html
+++ b/src/app/components/popup-error/popup-error.component.html
@@ -1,0 +1,12 @@
+<div
+  *ngFor="let error of getErrors()"
+  class="error">
+    {{error.errorText}}
+    <ng-container
+      *ngIf="error.hadleFunction"
+      class="userSelection">
+        <button (click)="handleError(error)">Yes</button>
+        <button (click)="clearError(error)">No</button>
+    </ng-container>
+    <button *ngIf="!error.handleFunction" (click)="clearError(error)">Ok</button>
+</div>

--- a/src/app/components/popup-error/popup-error.component.html
+++ b/src/app/components/popup-error/popup-error.component.html
@@ -3,7 +3,7 @@
   class="error">
     {{error.errorText}}
     <ng-container
-      *ngIf="error.hadleFunction"
+      *ngIf="error.handleFunction"
       class="userSelection">
         <button (click)="handleError(error)">Yes</button>
         <button (click)="clearError(error)">No</button>

--- a/src/app/components/popup-error/popup-error.component.spec.ts
+++ b/src/app/components/popup-error/popup-error.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PopupErrorComponent } from './popup-error.component';
+
+describe('PopupErrorComponent', () => {
+  let component: PopupErrorComponent;
+  let fixture: ComponentFixture<PopupErrorComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PopupErrorComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PopupErrorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/popup-error/popup-error.component.ts
+++ b/src/app/components/popup-error/popup-error.component.ts
@@ -1,0 +1,29 @@
+import { Component } from '@angular/core';
+import { PopUpError } from './../../models/pop-up-error.interface';
+import { ErrorService } from './../../services/error/error.service';
+
+@Component({
+  selector: 'app-popup-error',
+  templateUrl: './popup-error.component.html',
+  styleUrls: ['./popup-error.component.css']
+})
+export class PopupErrorComponent {
+
+  constructor(private errorService: ErrorService) {}
+
+  isErrors(): boolean {
+    return this.errorService.isErrors();
+  }
+
+  getErrors(): PopUpError[] {
+    return this.errorService.getErrors();
+  }
+
+  handleError(error: PopUpError) {
+    this.errorService.handleError(error);
+  }
+
+  clearError(error: PopUpError) {
+    this.errorService.clearError(error);
+  }
+}

--- a/src/app/models/pop-up-error.interface.ts
+++ b/src/app/models/pop-up-error.interface.ts
@@ -2,5 +2,5 @@ export interface PopUpError {
     errorText: string;
     errorDescription?: string;
     handleFunction?: Function;
-    callingObject?: Object;
+    callingScop?: Object;
 }

--- a/src/app/models/pop-up-error.interface.ts
+++ b/src/app/models/pop-up-error.interface.ts
@@ -2,5 +2,5 @@ export interface PopUpError {
     errorText: string;
     errorDescription?: string;
     handleFunction?: Function;
-    callingScop?: Object;
+    callingScope?: Object;
 }

--- a/src/app/models/pop-up-error.interface.ts
+++ b/src/app/models/pop-up-error.interface.ts
@@ -1,5 +1,6 @@
 export interface PopUpError {
     errorText: string;
+    errorDescription?: string;
     handleFunction?: Function;
     callingObject?: Object;
 }

--- a/src/app/models/pop-up-error.interface.ts
+++ b/src/app/models/pop-up-error.interface.ts
@@ -1,0 +1,5 @@
+export interface PopUpError {
+    errorText: string;
+    handleFunction?: Function;
+    callingObject?: Object;
+}

--- a/src/app/services/error/error.service.spec.ts
+++ b/src/app/services/error/error.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { ErrorService } from './error.service';
+
+describe('ErrorService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ErrorService]
+    });
+  });
+
+  it('should be created', inject([ErrorService], (service: ErrorService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/services/error/error.service.ts
+++ b/src/app/services/error/error.service.ts
@@ -8,18 +8,8 @@ export class ErrorService {
 
   errors: PopUpError[] = [];
 
-  addError(error: string) {
-    this.errors.push({errorText: error})
-  }
-  
-  addErrorWithOption(
-    error: string,
-    handleFunction: Function,
-    callingObject: Object): void {
-
-      this.errors.push({errorText: error,
-        handleFunction: handleFunction,
-        callingObject: callingObject});
+  addError(error: PopUpError): void {
+    this.errors.push(error);
   }
 
   getErrors(): PopUpError[] {

--- a/src/app/services/error/error.service.ts
+++ b/src/app/services/error/error.service.ts
@@ -26,7 +26,7 @@ export class ErrorService {
 
   handleError(error: PopUpError): void {
     if (error.handleFunction && typeof error.handleFunction === 'function') {
-      error.handleFunction.call(error.callingScop);
+      error.handleFunction.call(error.callingScope);
     }
     this.clearError(error);
   }

--- a/src/app/services/error/error.service.ts
+++ b/src/app/services/error/error.service.ts
@@ -17,7 +17,7 @@ export class ErrorService {
   }
 
   clearError(error: PopUpError): void {
-    this.errors.splice(this.errors.indexOf(error),1);
+    this.errors.splice(this.errors.indexOf(error), 1);
   }
 
   isErrors(): boolean {

--- a/src/app/services/error/error.service.ts
+++ b/src/app/services/error/error.service.ts
@@ -6,7 +6,7 @@ import { PopUpError } from './../../models/pop-up-error.interface';
 })
 export class ErrorService {
 
-  errors: PopUpError[] = [];
+  private errors: PopUpError[] = [];
 
   addError(error: PopUpError): void {
     this.errors.push(error);
@@ -21,11 +21,13 @@ export class ErrorService {
   }
 
   isErrors(): boolean {
-    return this.errors === [] ? false : true;
+    return !!this.errors.length;
   }
 
   handleError(error: PopUpError): void {
-    error.handleFunction.call(error.callingObject);
+    if (error.handleFunction && typeof error.handleFunction === 'function') {
+      error.handleFunction.call(error.callingScop);
+    }
     this.clearError(error);
   }
 }

--- a/src/app/services/error/error.service.ts
+++ b/src/app/services/error/error.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@angular/core';
+import { PopUpError } from './../../models/pop-up-error.interface';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ErrorService {
+
+  errors: PopUpError[] = [];
+
+  addError(error: string) {
+    this.errors.push({errorText: error})
+  }
+  
+  addErrorWithOption(
+    error: string,
+    handleFunction: Function,
+    callingObject: Object): void {
+
+      this.errors.push({errorText: error,
+        handleFunction: handleFunction,
+        callingObject: callingObject});
+  }
+
+  getErrors(): PopUpError[] {
+    return this.errors;
+  }
+
+  clearError(error: PopUpError): void {
+    this.errors.splice(this.errors.indexOf(error),1);
+  }
+
+  isErrors(): boolean {
+    return this.errors === [] ? false : true;
+  }
+
+  handleError(error: PopUpError): void {
+    error.handleFunction.call(error.callingObject);
+    this.clearError(error);
+  }
+}


### PR DESCRIPTION
The client is now capable of managing "_POP-UP_" errors

tooltip errors will still be part of the template for now.
We could change them to _pop-up_ at any time.

resolves #76