### PR TITLE
Running at cmd location

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -5,8 +5,7 @@
   "main": "../dist/out-tsc/server/server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node ../dist/out-tsc/server/server.js",
-    "start-browser": "node ../dist/out-tsc/server/server.js -o"
+    "start": "node ../dist/out-tsc/server/server.js -here -o"
   },
   "author": "Or Tichon",
   "license": "MIT",

--- a/server/server.ts
+++ b/server/server.ts
@@ -26,6 +26,9 @@ process.argv.forEach((val, index, array) => {
   if (val === '-o') {
     isOpenBrowser = true;
   }
+  if (val === '-here') {
+    process.chdir(process.env.INIT_CWD);
+  }
 });
 
 const processRunner = new ProcessRunner();
@@ -191,6 +194,7 @@ app.listen(PORT, () => {
   logger.log.clearContext();
   printLogo();
   // TODO: Add version/build number here
+  logger.log.debug(`Running at ${process.cwd()}`);
   logger.log.debug(`Listening on http://localhost:${PORT}`);
   if (isOpenBrowser) {
     openBrowser(PORT);


### PR DESCRIPTION
# Callable anywhere

 - Can be now called from any project [resolves #105]
   > Calling `npm start --prefix [ngWiz server folder path]` will now run the server at the current cmd folder
 
 - Will open the browser at `localhost:3000`
