### PR TITLE
fix code of conduct link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ today! As a contributor, here are the guidelines we would like you to follow:
  - [Running end-to-end tests](#ee-tests)
 
 ## <a name="coc"></a> Code of Conduct
-Help us keep ng-wiz open and inclusive. Please read and follow our [Code of Conduct][coc].
+Help us keep ng-wiz open and inclusive. Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## <a name="question"></a> Got a Question or Problem?
 


### PR DESCRIPTION
even though it was taken from a working example, didn't work for some reason. fixed this
